### PR TITLE
Update the recipe for Simbody 3.6.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,14 @@ environment:
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
+    - TARGET_ARCH: x86
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
+
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.
@@ -35,24 +43,24 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
     # Add our channels.
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda.exe config --set show_channel_urls true
+    - cmd: conda.exe config --remove channels defaults
+    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - conda build recipe --quiet
+    - conda.exe build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.5.4" %}
+{% set version = "3.6" %}
 {% set variant = "openblas" %}
 
 package:
@@ -8,15 +8,15 @@ package:
 source:
     fn: Simbody-{{ version }}.tar.gz
     url: https://github.com/simbody/simbody/archive/Simbody-{{ version }}.tar.gz
-    sha256: 449c36e574d6f859d4fa8854ab6bc8e402e5ca5894bcce3e9fdce2f5658d64de
+    sha256: bafce4b32dda4e174700733da1cd4f5f77f490daa96b92ed64bb881b0a885aa8
 
 build:
-    number: 205
+    number: 201
     # NOTE : For C++11 builds, vc14/VS 2015 are the only acceptable targets
-    # which only Python 3.5 supports. So skip previous Python versions.
-    skip: true                # [win and not py35]
+    # which only Python 3.5+ supports. So skip previous Python versions.
+    skip: true                # [win and not (py35 or py36)]
     features:
-        - vc14                # [win and py35]
+        - vc14                # [win and (py35 or py36)]
         - blas_{{ variant }}  # [unix]
     # NOTE : This is needed to ensure the paths to Simbody's binaries, like
     # simbody-visualizer, are corrected.
@@ -46,6 +46,7 @@ requirements:
 test:
   requires:
     - python 3.5.*  # [win and py35]
+    - python 3.6.*  # [win and py36]
   commands:
     - test -f $PREFIX/libexec/simbody/simbody-visualizer              # [unix]
     - if not exist %LIBRARY_BIN%\\simbody-visualizer.exe exit 1       # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ build:
 requirements:
     build:
         - toolchain
+        - clangdev                # [osx]
         - cmake >=2.8.6
         - blas 1.1 {{ variant }}  # [not win]
         - openblas 0.2.20|0.2.20.*        # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     sha256: bafce4b32dda4e174700733da1cd4f5f77f490daa96b92ed64bb881b0a885aa8
 
 build:
-    number: 201
+    number: 200
     # NOTE : For C++11 builds, vc14/VS 2015 are the only acceptable targets
     # which only Python 3.5+ supports. So skip previous Python versions.
     skip: true                # [win and not (py35 or py36)]


### PR DESCRIPTION
- [ ] Investigate if we can use the conda forge packages: [xorg-libxi](https://github.com/conda-forge/xorg-libxi-feedstock) and [xorg-libxmu](https://github.com/conda-forge/xorg-libxmu-feedstock).
- [ ] Simbody 3.6 seems to require GCC 4.9, is this available in the conda-forge tool chain?
- [ ] Add the docs? [doxygen](https://github.com/conda-forge/doxygen-feedstock) is available in conda-forge.
- [ ] Are we building with at least lapack 3.6? Seems like Opensim will require this.