### PR TITLE
Cmake osx vars

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,6 +15,8 @@ fi
 
 # -LAH prints the values of all CMake variables.
 cmake .. -LAH \
+    -DCMAKE_OSX_SYSROOT=${CONDA_BUILD_SYSROOT} \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} \
     -DCMAKE_INSTALL_PREFIX="$PREFIX" \
     -DCMAKE_INSTALL_LIBDIR="lib" \
     -DCMAKE_BUILD_TYPE="Release" \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: d371a92d440991400cb8e8e2473277a75307abb916e5aabc14194bea841b804a
 
 build:
-    number: 1
+    number: 2
     run_exports:
         - {{ pin_subpackage('simbody', max_pin='x.x') }}
     # NOTE : This is needed to ensure the paths to Simbody's binaries, like


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
The [conda-build documentation](https://docs.conda.io/projects/conda-build/en/latest/resources/compiler-tools.html?highlight=MACOSX_DEPLOYMENT_TARGET#macos-sdk) says:

> Build scripts for macOS should make use of the variables MACOSX_DEPLOYMENT_TARGET and CONDA_BUILD_SYSROOT, which are set by conda-build (see Environment variables). These variables should be translated into correct compiler arguments, e.g. for Clang this would be:
> 
> clang .. -isysroot ${CONDA_BUILD_SYSROOT} -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET} ..
> 
> Most build tools, e.g. CMake and distutils (setuptools), will automatically pick up MACOSX_DEPLOYMENT_TARGET but you need to pass CONDA_BUILD_SYSROOT explicitly. For CMake, this can be done with the option -DCMAKE_OSX_SYSROOT=${CONDA_BUILD_SYSROOT}.

Indeed, the [CMake documentation](https://cmake.org/cmake/help/v3.11/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html) says:

> If not set explicitly the value is initialized by the MACOSX_DEPLOYMENT_TARGET environment variable, if set, and otherwise computed based on the host platform.
> https://cmake.org/cmake/help/v3.11/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html